### PR TITLE
卒業判定処理機能の追加

### DIFF
--- a/app/Http/Controllers/GraduationController.php
+++ b/app/Http/Controllers/GraduationController.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\Models\CSVHandler;
+use App\Models\Requirement;
+
+class GraduationController extends Controller
+{
+    public function checkRequirements(Request $request)
+    {
+        // ファイルのバリデーション
+        $request->validate([
+            'csv_file' => 'required|file|mimes:csv,txt',
+        ]);
+
+        // CSVファイルを解析
+        $courses = CSVHandler::parseCSV($request->file('csv_file'));
+
+        // 卒業要件の取得とチェック
+        $result = Requirement::checkCompletion($courses);
+
+        // 判定結果をビューに渡す
+        return view('result', ['result' => $result['result'], 'status' => $result['status']]);
+    }
+}

--- a/app/Models/Course.php
+++ b/app/Models/Course.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Course extends Model
+{
+    /**
+     * 科目コードに基づいて分類を行う
+     */
+    public static function classifyCourse($courseCode)
+    {
+        // 1桁目: 大学院区分 (固定で '0')
+        if ($courseCode[0] !== '0') {
+            return '大学院課程外';
+        }
+
+        // 2桁目: 博士前期課程かどうかの確認
+        if ($courseCode[1] !== 'A') {
+            return '博士前期課程外';
+        }
+
+        // 3桁目: 研究群区分または共通科目の確認
+        $category = $courseCode[2];
+        switch ($category) {
+            case '0':
+                return '大学院共通科目';  // 細分なし
+            case 'A':
+                return '学術院共通専門基盤科目';  // 細分なし
+            case 'L':
+                return self::classifySystemInfoEngineering($courseCode);  // システム情報工学研究群の場合
+            default:
+                return '不明な科目区分';
+        }
+    }
+
+    /**
+     * システム情報工学研究群の科目分類
+     */
+    private static function classifySystemInfoEngineering($courseCode)
+    {
+        // 4桁目: 科目群分類
+        $subjectGroup = $courseCode[3];
+        if (preg_match('/[0-4]/', $subjectGroup)) {
+            return self::classifyCommonSubject($courseCode);
+        } elseif (preg_match('/[A-F]/', $subjectGroup)) {
+            return self::classifyProgramSubject($courseCode);
+        }
+
+        return '予備科目';
+    }
+
+    /**
+     * 研究群共通科目群の分類を行う
+     */
+    private static function classifyCommonSubject($courseCode)
+    {
+        $category = $courseCode[4];
+        switch ($category) {
+            case '0':
+                return '共通';
+            case '1':
+                return '社会工学関連科目';
+            case '2':
+                return 'サービス工学関連科目';
+            case '3':
+                return 'リスク・レジリエンス工学関連科目';
+            case '4':
+                return '情報理工関連科目';
+            case '5':
+                return '知能機能システム関連科目';
+            case '6':
+                return '構造エネルギー工学関連科目';
+            case '7':
+                return 'エンパワーメント情報学関連科目';
+            default:
+                return '予備';
+        }
+    }
+
+    /**
+     * 学位プログラム科目群の分類を行う
+     */
+    private static function classifyProgramSubject($courseCode)
+    {
+        $category = $courseCode[4];
+        if (preg_match('/[0-4]/', $category)) {
+            return '専門基礎科目';
+        } elseif (preg_match('/[5-9]/', $category)) {
+            return '専門科目';
+        }
+
+        return '予備';
+    }
+}

--- a/app/Models/Requirement.php
+++ b/app/Models/Requirement.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Requirement extends Model
+{
+    /**
+     * 卒業要件を取得
+     */
+    public static function getRequirements()
+    {
+        return [
+            '必修' => [
+                '専門科目' => [
+                    'required_units' => 12,  // 必修科目の単位数
+                    'category' => '学位プログラム科目群・専門科目',
+                ],
+            ],
+            '選択' => [
+                '大学院共通科目_社会工学以外' => [
+                    'required_units' => 2,
+                    'category' => '大学院共通科目・学術院共通専門基盤科目・研究群共通科目群・専門基礎科目',
+                    'social_engineering' => false,
+                ],
+                '研究群共通科目_専門基礎_社会工学' => [
+                    'required_units' => 6,
+                    'category' => '研究群共通科目群・専門基礎科目',
+                    'social_engineering' => true,
+                ],
+                '研究群共通科目_専門_社会工学' => [
+                    'required_units' => 10,
+                    'category' => '研究群共通科目群・専門科目',
+                    'social_engineering' => true,
+                ],
+                '研究群共通科目_専門_社会工学以外' => [
+                    'required_units' => 0,
+                    'category' => '研究群共通科目群・専門科目',
+                    'social_engineering' => false,
+                ],
+                '学位プログラム科目_専門基礎_社会工学' => [
+                    'required_units' => 0,
+                    'category' => '学位プログラム科目群・専門基礎科目',
+                    'social_engineering' => true,
+                ],
+                '学位プログラム科目_専門_社会工学' => [
+                    'required_units' => 0,
+                    'category' => '学位プログラム科目群・専門科目',
+                    'social_engineering' => true,
+                ],
+            ],
+            '総修得単位数' => 24,  // 選択科目の合計単位数
+        ];
+    }
+
+    /**
+     * 履修科目と卒業要件を照合し、判定を行う
+     */
+    public static function checkCompletion($courses)
+    {
+        $requirements = self::getRequirements();
+        $result = [
+            '必修' => 0,
+            '選択' => [
+                '大学院共通科目_社会工学以外' => 0,
+                '研究群共通科目_専門基礎_社会工学' => 0,
+                '研究群共通科目_専門_社会工学' => 0,
+                '研究群共通科目_専門_社会工学以外' => 0,
+                '学位プログラム科目_専門基礎_社会工学' => 0,
+                '学位プログラム科目_専門_社会工学' => 0,
+            ],
+            '総修得単位数' => 0,
+        ];
+
+        foreach ($courses as $course) {
+            $category = Course::classifyCourse($course['code']);
+            $units = $course['units'];
+
+            // 必修科目の単位数を計算
+            if ($category === '学位プログラム科目群・専門科目') {
+                $result['必修'] += $units;
+            }
+
+            // 選択科目の単位数を分類して計算
+            foreach ($requirements['選択'] as $requirementKey => $requirement) {
+                if ($category === $requirement['category'] && $requirement['social_engineering'] === $course['is_social_engineering']) {
+                    $result['選択'][$requirementKey] += $units;
+                    $result['総修得単位数'] += $units;
+                }
+            }
+        }
+
+        // 判定結果の評価
+        $status = [];
+        foreach ($requirements['選択'] as $key => $requirement) {
+            if ($result['選択'][$key] >= $requirement['required_units']) {
+                $status[$key] = '達成済';
+            } else {
+                $status[$key] = '未達成';
+            }
+        }
+
+        // 総単位数の判定
+        $status['総修得単位数'] = ($result['総修得単位数'] >= $requirements['総修得単位数']) ? '達成済' : '未達成';
+
+        return ['result' => $result, 'status' => $status];
+    }
+}

--- a/resources/views/result.blade.php
+++ b/resources/views/result.blade.php
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <title>卒業要件判定結果</title>
+</head>
+<body>
+    <h1>卒業要件判定結果</h1>
+
+    <h2>必修科目</h2>
+    <p>取得単位数: {{ $result['必修'] }} (12単位以上必要)</p>
+    <p>判定: {{ $status['必修'] }}</p>
+
+    <h2>選択科目</h2>
+    <table border="1">
+        <thead>
+            <tr>
+                <th>科目区分</th>
+                <th>必要単位数</th>
+                <th>取得単位数</th>
+                <th>判定</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach ($result['選択'] as $category => $units)
+                <tr>
+                    <td>{{ $category }}</td>
+                    <td>{{ $requirements['選択'][$category]['required_units'] }}</td>
+                    <td>{{ $units }}</td>
+                    <td>{{ $status[$category] }}</td>
+                </tr>
+            @endforeach
+        </tbody>
+    </table>
+
+    <h2>総修得単位数</h2>
+    <p>取得単位数: {{ $result['総修得単位数'] }} (24単位以上必要)</p>
+    <p>判定: {{ $status['総修得単位数'] }}</p>
+</body>
+</html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,22 +1,17 @@
 <?php
 
-use App\Models\Affiliation;
 use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\GraduationController;
 use App\Http\Controllers\AffiliationController;
 
-/*
-|--------------------------------------------------------------------------
-| Web Routes
-|--------------------------------------------------------------------------
-|
-| Here is where you can register web routes for your application. These
-| routes are loaded by the RouteServiceProvider and all of them will
-| be assigned to the "web" middleware group. Make something great!
-|
-*/
-
+// 学群・学類・専攻の選択フォームの表示php
 Route::get('/', [AffiliationController::class, 'showForm']);
 
-// 動的な選択肢を取得するためのルート
+// 学群に対応する学類を取得
 Route::get('/departments', [AffiliationController::class, 'getDepartments']);
+
+// 学類に対応する専攻を取得
 Route::get('/majors', [AffiliationController::class, 'getMajors']);
+
+// 卒業判定処理
+Route::post('/check', [GraduationController::class, 'checkRequirements']);


### PR DESCRIPTION
1. 卒業判定処理の実装
- ユーザーがアップロードした履修履歴を元に、卒業要件を満たしているかどうかを判定（GraduationController.php）
- 必修科目と選択科目の単位数を照合し、総修得単位数を判定

2. モデルの追加と更新
- Course.php: 履修科目の分類ロジックを実装し、科目コードに基づいて科目の種類（共通科目、専門科目など）を判定
- Requirement.php: 卒業要件を定義し、履修科目との照合を行う処理を追加

3. ビューの追加
- result.blade.php: 卒業判定結果をユーザーに表示するためのビューを作成