### PR TITLE
履修履歴CSVの説明文とTWINSリンクの追加・判定結果の表示を一部変更

### DIFF
--- a/resources/views/affiliation.blade.php
+++ b/resources/views/affiliation.blade.php
@@ -2,12 +2,12 @@
 <html lang="ja">
 <head>
     <meta charset="UTF-8">
-    <title>学術院・研究群・学位プログラムの選択</title>
+    <title>筑波大学大学院 卒業判定</title>
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
     <link rel="stylesheet" href="{{ asset('css/styles.css') }}">
 </head>
 <body>
-    <h1>学術院・研究群・学位プログラムの選択</h1>
+    <h1>筑波大学大学院 卒業判定</h1>
     <form action="/check" method="POST" enctype="multipart/form-data">
         @csrf
 
@@ -37,11 +37,22 @@
 
         <label for="csv_file">履修履歴CSV:</label>
         <input type="file" id="csv_file" name="csv_file" required>
-
-        <br><br>
+        <p>
+            履修履歴ファイルは
+            <a href="https://twins.tsukuba.ac.jp/campusweb/campusportal.do?page=main&tabId=si" target="_blank" rel="noopener noreferrer">
+                TWINS
+            </a>
+            の成績ページでダウンロードできます。形式はCSV、日本語（シフトJIS）にしてください。
+        </p>
 
         <button type="submit">卒業要件を確認</button>
+
+        <br><br>
     </form>
+
+    <footer>
+        <p>※履修履歴CSVはデータベースには保存されず、メモリ上で処理後に削除されます。</p>
+    </footer>
 
     <script>
         $(document).ready(function() {

--- a/resources/views/result.blade.php
+++ b/resources/views/result.blade.php
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <title>卒業要件判定結果</title>
+    <link rel="stylesheet" href="{{ asset('css/styles.css') }}">
 </head>
 <body>
     <h1>卒業要件判定結果</h1>
@@ -35,6 +36,7 @@
 
     <h2>総修得単位数</h2>
     <p>取得単位数: {{ $result['総修得単位数'] }} ({{ $requirements['選択合計'] }}単位以上必要)</p>
-    <p>判定: {{ $status['総修得単位数'] }}</p>
+    <h2>判定</h2>
+    <h3>{{ $status['総修得単位数'] }}</h3>
 </body>
 </html>


### PR DESCRIPTION
## 変更内容

1. 履修履歴CSVの取得方法の説明文を追加
    - フォーム内に以下の説明文を追加し、CSVファイルのダウンロード場所と形式を明確にしました
2. TWINSページへのリンクを紐づけ
- 「TWINSの成績ページ」の文言にリンクを設定し、クリックするとTWINSの成績ページが新しいタブで開くようにしました
3. 備考の追加
- ページ最下部に以下の備考を追加しました：
「※履修履歴CSVはデータベースには保存されず、メモリ上で処理後に削除されます。」
4. 判定結果の表示を一部変更
- 最終的な判定結果が目立つようにしました。